### PR TITLE
Use GITHUB_OUTPUT instead of deprecated set-output

### DIFF
--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Generate snapshot date
       id: snapshot-date
       run: |
-        echo ::set-output name=date::$(date -u +%Y%m%d)
+        echo "date=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
       shell: bash
 
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,7 @@ jobs:
           if [[ "${version}" == "${{ matrix.nginx-version }}" ]]; then
             key=image-refs-$(echo ${version} | sed 's|\.|-|g')
             value=$(./refs-to-json.sh | sed 's|"|\\"|g')
-            echo ::set-output name=${key}::${value}
+            echo "${key}=${value}" >> $GITHUB_OUTPUT
             break
           fi
         done
@@ -104,7 +104,7 @@ jobs:
         distroless_image: ghcr.io/${{ github.repository }}:${{ matrix.nginx-version }}
         docker_image_tag: ${{ matrix.nginx-version }}
         docker_image: "nginx"
-  
+
     - if: ${{ failure() }}
       uses: rtCamp/action-slack-notify@v2.2.0
       env:
@@ -145,7 +145,7 @@ jobs:
         cat image-refs-combined.json
         echo "---------------------------"
 
-        echo ::set-output name=image-refs::$(cat image-refs-combined.json)
+        echo "image-refs=$(cat image-refs-combined.json)" >> $GITHUB_OUTPUT
         rm -f image-refs-*.json
 
   scan:

--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -57,8 +57,8 @@ jobs:
           exit_code="0"
           [[ "${untracked_versions}" == "" ]] || exit_code="1"
           set -x
-          echo "::set-output name=untracked-versions::${untracked_versions}"
-          echo "::set-output name=exit-code::${exit_code}"
+          echo "untracked-versions=${untracked_versions}" >> $GITHUB_OUTPUT
+          echo "exit-code=${exit_code}" >> $GITHUB_OUTPUT
 
       - name: Post any untracked versions to Slack
         if: ${{ steps.compare.outputs.untracked-versions != '' }}


### PR DESCRIPTION

#### Summary
- Use GITHUB_OUTPUT instead of deprecated set-output

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/